### PR TITLE
restructure shows page

### DIFF
--- a/src/_data/shows.js
+++ b/src/_data/shows.js
@@ -74,7 +74,16 @@ function sortShows(shows) {
   return { upcoming, past };
 }
 
+const improv = sortShows(showsRaw.improv);
+const music = sortShows(showsRaw.music);
+
 module.exports = {
-  improv: sortShows(showsRaw.improv),
-  music: sortShows(showsRaw.music)
+  upcoming: {
+    music: music.upcoming,
+    improv: improv.upcoming
+  },
+  past: {
+    music: music.past,
+    improv: improv.past
+  }
 };

--- a/src/_includes/macros/renderShows.njk
+++ b/src/_includes/macros/renderShows.njk
@@ -1,71 +1,42 @@
-{% macro renderShows(showList, title) %}
-<section class="shows-section">
-  <h2>{{ title }}</h2>
-
-  {# --- Upcoming Shows --- #}
-  <h3>Upcoming</h3>
-  {% if showList.upcoming.length %}
-    <table class="shows-table">
-      <thead>
-        <tr>
-          <th>Date</th>
-          <th>Title</th>
-          <th>Venue</th>
-          <th>Tickets</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for show in showList.upcoming %}
+{% macro renderShows(showList, title, defaultOpen=true) %}
+<section class="shows-section" x-data="{ open: {{ 'true' if defaultOpen else 'false' }} }">
+  <h3>
+    <button class="collapsible-toggle" @click="open = !open" :aria-expanded="open">
+      {{ title }}
+      <span x-text="open ? '▲' : '▼'"></span>
+    </button>
+  </h3>
+  <div x-show="open" x-cloak>
+    {% if showList.length %}
+      <table class="shows-table">
+        <thead>
           <tr>
-            <td>{{ show.date }}</td>
-            <td>{{ show.title }}</td>
-            <td>{{ show.venue }}</td>
-            <td>
-              {% if show.tickets %}
-                <a href="{{ show.tickets }}" target="_blank" rel="noopener">Tickets</a>
-              {% else %}
-                —
-              {% endif %}
-            </td>
+            <th>Date</th>
+            <th>Title</th>
+            <th>Venue</th>
+            <th>Tickets</th>
           </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  {% else %}
-    <p>No upcoming shows.</p>
-  {% endif %}
-
-  {# --- Past Shows --- #}
-  <h3>Past</h3>
-  {% if showList.past.length %}
-    <table class="shows-table">
-      <thead>
-        <tr>
-          <th>Date</th>
-          <th>Title</th>
-          <th>Venue</th>
-          <th>Tickets</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for show in showList.past %}
-          <tr>
-            <td>{{ show.date }}</td>
-            <td>{{ show.title }}</td>
-            <td>{{ show.venue }}</td>
-            <td>
-              {% if show.tickets %}
-                <a href="{{ show.tickets }}" target="_blank" rel="noopener">Tickets</a>
-              {% else %}
-                —
-              {% endif %}
-            </td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  {% else %}
-    <p>No past shows yet.</p>
-  {% endif %}
+        </thead>
+        <tbody>
+          {% for show in showList %}
+            <tr>
+              <td>{{ show.date }}</td>
+              <td>{{ show.title }}</td>
+              <td>{{ show.venue }}</td>
+              <td>
+                {% if show.tickets %}
+                  <a href="{{ show.tickets }}" target="_blank" rel="noopener">Tickets</a>
+                {% else %}
+                  —
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p>No shows.</p>
+    {% endif %}
+  </div>
 </section>
 {% endmacro %}

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -147,6 +147,24 @@ h1, h2, h3, h4, h5, h6 {
   clear: left;
 }
 
+/* Collapsible section toggle */
+.collapsible-toggle {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: monospace;
+  font-size: inherit;
+  font-weight: inherit;
+  color: inherit;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.collapsible-toggle:hover {
+  color: var(--color-frog-green);
+}
+
 /* Shows table */
 .shows-table {
   width: 100%;

--- a/src/shows.njk
+++ b/src/shows.njk
@@ -8,5 +8,10 @@ permalink: /shows/
 
 <h1 class="text-3xl font-mono mb-8">Shows</h1>
 
-{{ renderShows(shows.improv, "Improv") }}
-{{ renderShows(shows.music, "Music") }}
+<h2>Upcoming</h2>
+{{ renderShows(shows.upcoming.music, "Music") }}
+{{ renderShows(shows.upcoming.improv, "Improv") }}
+
+<h2>Past</h2>
+{{ renderShows(shows.past.music, "Music", false) }}
+{{ renderShows(shows.past.improv, "Improv", false) }}


### PR DESCRIPTION
Restructures the Shows page layout so that Upcoming and Past are the top-level sections (h2), with Music and Improv as subsections (h3) under each.

  The Music and Improv subsections are collapsible via Alpine.js — Upcoming defaults to open, Past defaults to closed.

  Files changed:
  - src/_data/shows.js — re-exports data grouped by timing (upcoming/past) then category (music/improv)
  - src/_includes/macros/renderShows.njk — simplified macro accepts a flat show list, title, and defaultOpen flag; renders collapsible h3 sections
  - src/shows.njk — updated to use new data shape and h2/h3 structure
  - src/public/styles.css — adds .collapsible-toggle button styles