### PR TITLE
add reading time estimates and post excerpts

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -32,6 +32,31 @@ module.exports = function (eleventyConfig) {
       .sort((a, b) => new Date(a.data.date) - new Date(b.data.date));
   });
 
+  const H1_RE = /<h1[^>]*>.*?<\/h1>/is;
+  const stripHtml = str => str.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+
+  eleventyConfig.addFilter("postTitle", function(content) {
+    const match = content.match(/<h1[^>]*>(.*?)<\/h1>/is);
+    return match ? match[1].replace(/<[^>]+>/g, "") : "";
+  });
+
+  eleventyConfig.addFilter("removeH1", function(content) {
+    return content.replace(H1_RE, "");
+  });
+
+  eleventyConfig.addFilter("readingTime", function(content) {
+    const words = stripHtml(content).split(/\s+/).length;
+    return `${Math.ceil(words / 200)} min read`;
+  });
+
+  eleventyConfig.addFilter("excerpt", function(content) {
+    const text = stripHtml(content.replace(H1_RE, ""));
+    if (text.length <= 150) return text;
+    const trimmed = text.slice(0, 150);
+    const lastSpace = trimmed.lastIndexOf(" ");
+    return (lastSpace > 0 ? trimmed.slice(0, lastSpace) : trimmed) + "…";
+  });
+
   // Filter to parse a date string into a timestamp
   eleventyConfig.addFilter("toTimestamp", function(dateStr) {
     return new Date(dateStr).getTime();

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -25,7 +25,13 @@
     </ul>
   </nav>
   <main>
-    {{ content | safe }}
+    {% if tags and "post" in tags %}
+      <h1>{{ content | postTitle }}</h1>
+      <p class="post-meta">{{ content | readingTime }}</p>
+      {{ content | removeH1 | safe }}
+    {% else %}
+      {{ content | safe }}
+    {% endif %}
   </main>
   <footer>
     <p>© 2025 Dan Marino</p>

--- a/src/posts.njk
+++ b/src/posts.njk
@@ -16,9 +16,13 @@ permalink: "/posts/index.html"
       <h2 class="w-24 shrink-0 text-right pr-4 text-gray-400 font-mono text-sm">{{ year }}</h2>
       <div class="flex-1 space-y-2">
         {% for post in posts %}
-          <div class="flex items-baseline space-x-4">
-            <span class="text-gray-500 text-xs font-mono w-24">{{ post.date | date("MMM d") }}</span>
-            <a href="{{ post.url }}">{{ post.data.title }}</a>
+          <div class="post-list-item">
+            <div class="post-list-header">
+              <span class="post-list-date">{{ post.date | date("MMM d") }}</span>
+              <a href="{{ post.url }}">{{ post.data.title }}</a>
+              <span class="post-list-meta">{{ post.templateContent | readingTime }}</span>
+            </div>
+            <p class="post-list-excerpt">{{ post.templateContent | excerpt }}</p>
           </div>
         {% endfor %}
       </div>

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -10,8 +10,7 @@
   --color-olive-green: #485e37;
   --color-white: #eeeeee;
   --color-black: #000000;
-  --color-muted: var(--color-muted);
-  --font-size-small: 13px;
+  --color-muted: #5b5d5b;
 }
 
 /* Base resets */
@@ -169,19 +168,16 @@ h1, h2, h3, h4, h5, h6 {
 }
 .post-list-date {
   color: var(--color-dark-gray);
-  font-size: var(--font-size-small);
   white-space: nowrap;
   min-width: 3.5rem;
 }
 .post-list-meta {
-  font-size: var(--font-size-small);
   color: var(--color-muted);
   font-style: italic;
   white-space: nowrap;
 }
 .post-list-excerpt {
   margin: 0.2rem 0 0 0;
-  font-size: var(--font-size-small);
   color: var(--color-muted);
   padding-left: calc(3.5rem + 0.75rem);
 }

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -10,6 +10,8 @@
   --color-olive-green: #485e37;
   --color-white: #eeeeee;
   --color-black: #000000;
+  --color-muted: var(--color-muted);
+  --font-size-small: 13px;
 }
 
 /* Base resets */
@@ -145,6 +147,43 @@ h1, h2, h3, h4, h5, h6, p {
 
 h1, h2, h3, h4, h5, h6 {
   clear: left;
+}
+
+/* Post meta (read time on individual post) */
+.post-meta {
+  font-size: 15px;
+  color: var(--color-muted);
+  font-style: italic;
+  margin-top: 0.25rem;
+  margin-bottom: 0;
+}
+
+/* Posts list */
+.post-list-item {
+  margin-bottom: 1.2rem;
+}
+.post-list-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+.post-list-date {
+  color: var(--color-dark-gray);
+  font-size: var(--font-size-small);
+  white-space: nowrap;
+  min-width: 3.5rem;
+}
+.post-list-meta {
+  font-size: var(--font-size-small);
+  color: var(--color-muted);
+  font-style: italic;
+  white-space: nowrap;
+}
+.post-list-excerpt {
+  margin: 0.2rem 0 0 0;
+  font-size: var(--font-size-small);
+  color: var(--color-muted);
+  padding-left: calc(3.5rem + 0.75rem);
 }
 
 /* Collapsible section toggle */


### PR DESCRIPTION
Adds estimated reading time and a short excerpt preview to the posts experience.

  Posts list (/posts/): Each post now shows an italicized read time estimate inline with the title, and a 150-character plain-text excerpt below it.

  Individual post pages: The read time appears directly under the article title, in the same italic muted style.

  Implementation:
  - src/_data/.eleventy.js — four new Eleventy filters: postTitle (extracts h1 text), removeH1 (strips h1 from content), readingTime (word count ÷ 200 wpm), and excerpt (first ~150 chars of plain text, trimmed to a word boundary). Shared H1_RE
  regex constant and stripHtml helper keep the filters DRY.
  - src/_includes/layout.njk — for post pages, the h1 is extracted and rendered separately so the read time can be injected between the title and the body.
  - src/posts.njk — updated post list markup to include read time and excerpt per entry.
  - src/public/styles.css — new styles for .post-meta, .post-list-item, .post-list-header, .post-list-date, .post-list-meta, and .post-list-excerpt. Added --color-muted and --font-size-small CSS variables.