### PR TITLE
add tag support with per-tag pages and posts page filter

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -28,6 +28,40 @@ module.exports = function (eleventyConfig) {
       .map(([year, posts]) => [year, posts.sort((a, b) => b.date - a.date)]); // newest post first within year
   });
 
+  // All unique tags from posts (excluding "post" itself)
+  eleventyConfig.addCollection("tagList", function(collectionApi) {
+    const tags = new Set();
+    collectionApi.getFilteredByTag("post").forEach(post => {
+      const t = post.data.tags;
+      const arr = Array.isArray(t) ? t : (t ? [t] : []);
+      arr.forEach(tag => { if (tag !== "post") tags.add(tag); });
+    });
+    return [...tags].sort();
+  });
+
+  // Filter: strips the "post" sentinel tag, returns the rest
+  eleventyConfig.addFilter("postTags", function(tags) {
+    if (!tags) return [];
+    const arr = Array.isArray(tags) ? tags : [tags];
+    return arr.filter(t => t !== "post");
+  });
+
+  // Filter: returns all unique non-"post" tags across an array of posts
+  eleventyConfig.addFilter("yearTags", function(posts) {
+    const tags = new Set();
+    posts.forEach(post => {
+      const t = post.data.tags;
+      const arr = Array.isArray(t) ? t : (t ? [t] : []);
+      arr.forEach(tag => { if (tag !== "post") tags.add(tag); });
+    });
+    return [...tags];
+  });
+
+  // Filter: serialize a value to a JSON string for use in Alpine.js expressions
+  eleventyConfig.addFilter("json", function(value) {
+    return JSON.stringify(value);
+  });
+
   // Custom collection for shows
   eleventyConfig.addCollection("shows", (collectionApi) => {
     return collectionApi.getFilteredByGlob("src/shows/**/*.{json,md}")

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -28,6 +28,14 @@
     {% if tags and "post" in tags %}
       <h1>{{ content | postTitle }}</h1>
       <p class="post-meta">{{ content | readingTime }}</p>
+      {% set postTagList = tags | postTags %}
+      {% if postTagList.length %}
+        <div class="post-tags">
+          {% for t in postTagList %}
+            <a href="/tags/{{ t }}/" class="tag">#{{ t }}</a>
+          {% endfor %}
+        </div>
+      {% endif %}
       {{ content | removeH1 | safe }}
     {% else %}
       {{ content | safe }}

--- a/src/posts.njk
+++ b/src/posts.njk
@@ -8,25 +8,51 @@ pagination:
 permalink: "/posts/index.html"
 ---
 
-<h1 class="text-3xl font-mono mb-8">Posts</h1>
+<h1>Posts</h1>
 
-<div class="space-y-12">
-  {% for year, posts in collections.postsByYear %}
-    <div class="flex">
-      <h2 class="w-24 shrink-0 text-right pr-4 text-gray-400 font-mono text-sm">{{ year }}</h2>
-      <div class="flex-1 space-y-2">
-        {% for post in posts %}
-          <div class="post-list-item">
-            <div class="post-list-header">
-              <span class="post-list-date">{{ post.date | date("MMM d") }}</span>
-              <a href="{{ post.url }}" class="post-list-title">{{ post.data.title }}</a>
-              <span class="post-list-meta">{{ post.templateContent | readingTime }}</span>
+<div x-data="{ activeTag: null }">
+
+  <div class="tag-filter">
+    <button
+      class="tag tag-btn"
+      :class="{ 'tag-active': activeTag === null }"
+      @click="activeTag = null">all</button>
+    {% for tag in collections.tagList %}
+      <button
+        class="tag tag-btn"
+        :class="{ 'tag-active': activeTag === '{{ tag }}' }"
+        @click="activeTag = activeTag === '{{ tag }}' ? null : '{{ tag }}'">#{{ tag }}</button>
+    {% endfor %}
+  </div>
+
+  <div class="space-y-12">
+    {% for year, yearPosts in collections.postsByYear %}
+      {% set yearTagsArr = yearPosts | yearTags %}
+      <div class="flex" x-show="activeTag === null || {{ yearTagsArr | json }}.includes(activeTag)">
+        <h2 class="w-24 shrink-0 text-right pr-4 text-gray-400 font-mono text-sm">{{ year }}</h2>
+        <div class="flex-1 space-y-2">
+          {% for post in yearPosts %}
+            {% set postTagsArr = post.data.tags | postTags %}
+            <div class="post-list-item" x-show="activeTag === null || {{ postTagsArr | json }}.includes(activeTag)">
+              <div class="post-list-header">
+                <span class="post-list-date">{{ post.date | date("MMM d") }}</span>
+                <a href="{{ post.url }}" class="post-list-title">{{ post.data.title }}</a>
+                <span class="post-list-meta">{{ post.templateContent | readingTime }}</span>
+              </div>
+              <p class="post-list-excerpt">{{ post.templateContent | excerpt }}</p>
+              {% set postTagList = post.data.tags | postTags %}
+              {% if postTagList.length %}
+                <div class="post-list-tags">
+                  {% for t in postTagList %}
+                    <a href="/tags/{{ t }}/" class="tag">#{{ t }}</a>
+                  {% endfor %}
+                </div>
+              {% endif %}
             </div>
-            <p class="post-list-excerpt">{{ post.templateContent | excerpt }}</p>
-          </div>
-        {% endfor %}
+          {% endfor %}
+        </div>
       </div>
-    </div>
-  {% endfor %}
-</div>
+    {% endfor %}
+  </div>
 
+</div>

--- a/src/posts/2025/2025-06-01-first-test-post.md
+++ b/src/posts/2025/2025-06-01-first-test-post.md
@@ -1,7 +1,9 @@
 ---
 title: "First Test Post"
 date: 2025-06-01
-tags: post
+tags:
+  - post
+  - meta
 layout: layout.njk
 ---
 

--- a/src/posts/2026/2026-04-06-the-album-creation-process.md
+++ b/src/posts/2026/2026-04-06-the-album-creation-process.md
@@ -1,7 +1,9 @@
 ---
 title: "The Album Creation Process"
 date: 2026-04-06
-tags: post
+tags:
+  - post
+  - music
 layout: layout.njk
 ---
 

--- a/src/posts/2026/2026-04-09-looking-for-musicians.md
+++ b/src/posts/2026/2026-04-09-looking-for-musicians.md
@@ -1,7 +1,9 @@
 ---
 title: "Looking for Bandmates"
 date: 2026-04-09
-tags: post
+tags:
+  - post
+  - music
 layout: layout.njk
 ---
 

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -184,6 +184,52 @@ h1, h2, h3, h4, h5, h6 {
   color: var(--color-muted);
   padding-left: calc(3.5rem + 0.75rem);
 }
+.post-list-tags {
+  margin: 0.3rem 0 0;
+  padding-left: calc(3.5rem + 0.75rem);
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+/* Tag badges */
+.tag {
+  display: inline-block;
+  font-size: 11px;
+  color: var(--color-olive-green);
+  border: 1px solid var(--color-olive-green);
+  padding: 0.1rem 0.35rem;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.tag:hover {
+  background-color: var(--color-olive-green);
+  color: var(--color-white);
+}
+
+/* Tags on individual post pages */
+.post-tags {
+  margin: 0.25rem 0 1rem;
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+/* Tag filter bar on posts page */
+.tag-filter {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}
+.tag-btn {
+  background: none;
+  cursor: pointer;
+}
+.tag-active {
+  background-color: var(--color-olive-green);
+  color: var(--color-white);
+}
 
 /* Collapsible section toggle */
 .collapsible-toggle {

--- a/src/tags/tag.njk
+++ b/src/tags/tag.njk
@@ -1,0 +1,27 @@
+---
+layout: layout.njk
+pagination:
+  data: collections.tagList
+  size: 1
+  alias: tag
+permalink: "/tags/{{ tag }}/"
+eleventyComputed:
+  title: "#{{ tag }}"
+---
+
+<h1>#{{ tag }}</h1>
+
+<p><a href="/posts/">← all posts</a></p>
+
+<div>
+  {% for post in collections[tag] | reverse %}
+    <div class="post-list-item">
+      <div class="post-list-header">
+        <span class="post-list-date">{{ post.date | date("MMM d") }}</span>
+        <a href="{{ post.url }}" class="post-list-title">{{ post.data.title }}</a>
+        <span class="post-list-meta">{{ post.templateContent | readingTime }}</span>
+      </div>
+      <p class="post-list-excerpt">{{ post.templateContent | excerpt }}</p>
+    </div>
+  {% endfor %}
+</div>


### PR DESCRIPTION
- Add tags frontmatter to existing posts (music, meta)
- Generate static /tags/[tag]/ pages via pagination
- Show tag badges on post list and individual post pages
- Add Alpine.js tag filter bar to posts page for client-side filtering
- Add tagList, yearTags, json, postTags filters to eleventy config